### PR TITLE
Update nixpkgs and liqwid-nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -451,14 +451,15 @@
     },
     "liqwid-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-2205": "nixpkgs-2205"
       },
       "locked": {
-        "lastModified": 1659383708,
-        "narHash": "sha256-eenTO5t4ocK7VzorMUdUyKUoup976cCu5dJcVjebY8E=",
+        "lastModified": 1666695559,
+        "narHash": "sha256-v8DcNma4hAgLCbPHpsxNYzeMURfbxh20VXfFzUED6bs=",
         "owner": "Liqwid-Labs",
         "repo": "liqwid-nix",
-        "rev": "c261df76dc31b3dc5dfde7030420e0a6be73f615",
+        "rev": "7add1f24e9360e96b2bab4a1fc7929d4fa649439",
         "type": "github"
       },
       "original": {
@@ -598,19 +599,34 @@
         "type": "github"
       }
     },
-    "nixpkgs-latest": {
+    "nixpkgs-2205": {
       "locked": {
-        "lastModified": 1653918805,
-        "narHash": "sha256-6ahwAnBNGgqSNSn/6RnsxrlFi+fkA+RyT6o/5S1915o=",
+        "lastModified": 1660033036,
+        "narHash": "sha256-GjwzXmdN5SVTT0RIZ11uDTQxaHLTLt9/AbBeIHNfidQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a0a69be4b5ee63f1b5e75887a406e9194012b492",
+        "rev": "490f6174c03132bf8f078d0f3a6e5890a47f9b30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-latest": {
+      "locked": {
+        "lastModified": 1666902743,
+        "narHash": "sha256-uCQcqfI4QhNGBbVb48ggqK3oVqg9MyU6Wz9N5bhiLOw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b9a643f139e73ef95d3bd131cb4d8ee6dd7d8d23",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a0a69be4b5ee63f1b5e75887a406e9194012b492",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.follows = "plutarch/nixpkgs";
-    nixpkgs-latest.url = "github:NixOS/nixpkgs?rev=a0a69be4b5ee63f1b5e75887a406e9194012b492";
+    nixpkgs-latest.url = "github:NixOS/nixpkgs";
 
     # temporary fix for nix versions that have the transitive follows bug
     # see https://github.com/NixOS/nix/issues/6013
@@ -36,10 +36,7 @@
       [
         liqwid-nix.haskellProject
         liqwid-nix.plutarchProject
-        (liqwid-nix.addChecks
-          {
-            plutarch-numeric = "plutarch-numeric:lib:plutarch-numeric";
-          })
+        liqwid-nix.addBuildChecks
         (liqwid-nix.enableFormatCheck [
           "-XTemplateHaskell"
           "-XTypeApplications"


### PR DESCRIPTION
Updates to the version of `liqwid-nix` used in the rest of the ecosystem e.g. `liqwid-onchain`. The current version conflicts when we try to reuse dependencies (i.e. `follows`) due to `addChecks` being updated to `addBuildChecks`.

See https://github.com/Liqwid-Labs/plutarch-unit/pull/6 for context